### PR TITLE
Remove Golang word

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Forseti Config Validator
 
-This is a Golang library which provides functionality to evaluate
+Forseti Config Validator is a Go library which provides functionality to evaluate
 GCP resources against Rego-based policies. It can be used to add
 config policy support to new projects without having to integrate
 Rego parsing directly.


### PR DESCRIPTION
Go is not Golang, it's Go. Calling it Golang can make some people grumpy! 😃