### PR TITLE
Update gsutil cp instruction for policy library

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -331,7 +331,8 @@ repository:
 ```
 export FORSETI_BUCKET=`terraform output -module=forseti forseti-server-storage-bucket`
 export POLICY_LIBRARY_PATH=path/to/local/policies/library
-gsutil cp -r ${POLICY_LIBRARY_PATH} gs://${FORSETI_BUCKET}/policy-library/
+gsutil -m rsync -d -r ${POLICY_LIBRARY_PATH}/policies gs://${FORSETI_BUCKET}/policy-library/policies
+gsutil -m rsync -d -r ${POLICY_LIBRARY_PATH}/lib gs://${FORSETI_BUCKET}/policy-library/lib
 ```
 
 Example result:


### PR DESCRIPTION
Forseti only needs the policies and lib dirs. Also use rsync instead of cp since we want to mirror the content.