### PR TITLE
Update config test

### DIFF
--- a/pkg/gcv/configs/config_test.go
+++ b/pkg/gcv/configs/config_test.go
@@ -462,11 +462,15 @@ metadata:
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			result, err := CategorizeYAMLFile([]byte(tc.data), tc.description)
+			gotErr := (err != nil)
+			if tc.wantErr != gotErr {
+				t.Errorf("want err %v, got %v", tc.wantErr, err)
+			}
+			if err != nil {
+				return
+			}
 			if diff := cmp.Diff(tc.expected, result, cmpopts.IgnoreUnexported(simpleyaml.Yaml{})); diff != "" {
 				t.Errorf("%s (-want, +got) %v", tc.description, diff)
-			}
-			if err == nil && tc.wantErr {
-				t.Errorf("want err %v, got %v", tc.wantErr, err)
 			}
 		})
 	}


### PR DESCRIPTION
I was getting the following failure:
```
--- FAIL: TestCategorizeYAMLFile (0.00s)
    --- FAIL: TestCategorizeYAMLFile/invalid_template_invalid_target (0.00s)
        config_test.go:466: invalid template invalid target (-want, +got) :
            	-: <non-existent>
            	+: (*configs.ConstraintTemplate)(nil)
    --- FAIL: TestCategorizeYAMLFile/invalid_constraint_uses_template_kind (0.00s)
        config_test.go:466: invalid constraint uses template kind (-want, +got) :
            	-: <non-existent>
            	+: (*configs.Constraint)(nil)
    --- FAIL: TestCategorizeYAMLFile/invalid_constraint_uses_template_api_version (0.00s)
        config_test.go:466: invalid constraint uses template api version (-want, +got) :
            	-: <non-existent>
            	+: (*configs.ConstraintTemplate)(nil)
```

We don't need to look at the result at all if there's an error. Updated the test to incorporate this behavior.