### PR TITLE
Update matching logic to not require gcp wrapper field

### DIFF
--- a/pkg/gcv/cf/cf_test.go
+++ b/pkg/gcv/cf/cf_test.go
@@ -1309,7 +1309,7 @@ spec:
       names:
         kind: %s
   targets:
-   validation.gcp.forsetisecurity.org:
+    - target: validation.gcp.forsetisecurity.org
       rego: |
             package templates.gcp.%s
 


### PR DESCRIPTION
See #42 for context.
Also update the test template to use the new format for targets.

We'll temporarily accept both forms (with and without gcp wrapper). The plan to is to remove the support for gcp wrapper at a later date.