### PR TITLE
Adding Dockerfile to build server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First build the config-validator binary
+FROM golang:1.11 as build
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN make release
+
+# Now copy it into our static image.
+FROM gcr.io/distroless/static:nonroot
+
+COPY --chown=nonroot:nonroot --from=build /go/src/app/bin/config-validator-linux-amd64 /app
+ENTRYPOINT ["/app"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,3 +7,6 @@ steps:
 - name: 'golang'
   env: ['GO111MODULE=on', 'CLOUDBUILD=on']
   args: ['go', 'test', '-v', '-cover', './...']
+- name: 'gcr.io/cloud-builders/docker'
+  id: Test build of server container
+  args: ['build', '-t', 'config-validator', '.']


### PR DESCRIPTION
This is in support of the effort in running Forseti on GKE.

I recommend we place the server Dockerfile in the root of the repository since the docker context is the entire repo.