### PR TITLE
Implement ConstraintFramework.Review

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -58,7 +58,7 @@ func (s *gcvServer) Audit(ctx context.Context, request *validator.AuditRequest) 
 }
 
 func (s *gcvServer) Reset(ctx context.Context, request *validator.ResetRequest) (*validator.ResetResponse, error) {
-	err := s.validator.Reset()
+	err := s.validator.Reset(ctx)
 	if err != nil {
 		return &validator.ResetResponse{}, status.Error(codes.Internal, err.Error())
 	}

--- a/pkg/gcv/cf/parsing.go
+++ b/pkg/gcv/cf/parsing.go
@@ -60,7 +60,7 @@ func convertToViolations(expression *rego.ExpressionValue) ([]*validator.Violati
 	if err != nil {
 		return nil, err
 	}
-	violations := []*validator.Violation{}
+	var violations []*validator.Violation
 	for i := 0; i < len(parsedExpression); i++ {
 		violationToAdd := &validator.Violation{
 			Constraint: parsedExpression[i].Constraint,

--- a/pkg/gcv/validator.go
+++ b/pkg/gcv/validator.go
@@ -160,9 +160,8 @@ func (v *Validator) Review(ctx context.Context, request *validator.ReviewRequest
 }
 
 // Reset clears previously added data from the underlying query evaluation engine.
-func (v *Validator) Reset() error {
-	v.constraintFramework.Reset()
-	return nil
+func (v *Validator) Reset(ctx context.Context) error {
+	return v.constraintFramework.Reset(ctx)
 }
 
 // Audit checks the GCP resource metadata that has been added via AddData to determine if any of the constraint is violated.


### PR DESCRIPTION
* This is intended to be a functional impl of Review.  Multithreaded
support will come in a following patch.
* Fix up ConstrintFramework.Reset.  Prior to this, we weren't clearing
store.  In theory, this won't really matter since we re-create inventory
on each call to audit, but this would cause weird artifacts if people
start calling AddData then Reset then Review (which we don't really plan
to support, but we would not want to support the bugs resulting from the
weird behavior).