### PR TITLE
generate error when no configuration is loaded

### DIFF
--- a/pkg/gcv/configs/config.go
+++ b/pkg/gcv/configs/config.go
@@ -349,6 +349,9 @@ func loadUnstructured(dirs []string) ([]*unstructured.Unstructured, error) {
 			yamlDocs = append(yamlDocs, &u)
 		}
 	}
+	if len(yamlDocs) == 0 {
+		return nil, fmt.Errorf("zero configurations found in the provided directories: %v", dirs)
+	}
 	return yamlDocs, nil
 }
 

--- a/pkg/gcv/validator_test.go
+++ b/pkg/gcv/validator_test.go
@@ -238,8 +238,8 @@ func TestCreateEmptyDir(t *testing.T) {
 
 	stopChannel := make(chan struct{})
 	defer close(stopChannel)
-	if _, err = NewValidator(stopChannel, []string{policyDir}, policyLibDir); err != nil {
-		t.Fatal("empty dir not expected to provide error: ", err)
+	if _, err = NewValidator(stopChannel, []string{policyDir}, policyLibDir); err == nil {
+		t.Fatal("directory without a configuration should generate error")
 	}
 }
 


### PR DESCRIPTION
Validator should be fail-safe that if there is a misconfiguration that results in zero configurations loaded, it should generate an error.

This should not be confused with the use case where *one* of the directory is empty but some configurations are loaded. This pull request allow that use case.