### PR TITLE
Fix OpenAPISpec conversion issue.

### DIFF
--- a/test/cf/templates/gcp_bq_dataset_location_v1.yaml
+++ b/test/cf/templates/gcp_bq_dataset_location_v1.yaml
@@ -1,0 +1,180 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This template is for policies restricting the locations 
+# of BigQuery datasets to specific locations in GCP. It supports 
+# allowlist or denylist modes, as well as exempting selected 
+# datasets from the list.
+
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-bigquery-dataset-location-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPBigQueryDatasetLocationConstraintV1
+        plural: gcpbigquerydatasetlocationconstraintsv1
+      validation:
+        openAPIV3Schema:
+          properties:
+            mode:
+              type: string
+              enum: [denylist, allowlist]
+              description: "String identifying the operational mode, allowlist or denylist. In allowlist mode, 
+              datasets are only allowed in the locations specified in the 'locations' parameter. In denylist mode, 
+              resources are allowed in all locations except those listed in the 'locations' parameter."
+            exemptions:
+              type: array
+              items: string
+              description: "Array of datasets to exempt from location restriction. String values in the array should 
+              correspond to the full name values of exempted datasets."
+            locations:
+              type: array
+              items: string
+              description: "Array of location names to be allowed or denied. Should be the the location name, whether regional  
+              (e.g. us-west2) or multi-regional (e.g. EU), as defined at https://cloud.google.com/bigquery/docs/locations."
+  targets:
+    validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/bq_dataset_location.rego")
+           
+           #
+           
+           # Copyright 2019 Google LLC
+           
+           #
+           
+           # Licensed under the Apache License, Version 2.0 (the "License");
+           
+           # you may not use this file except in compliance with the License.
+           
+           # You may obtain a copy of the License at
+           
+           #
+           
+           #      http://www.apache.org/licenses/LICENSE-2.0
+           
+           #
+           
+           # Unless required by applicable law or agreed to in writing, software
+           
+           # distributed under the License is distributed on an "AS IS" BASIS,
+           
+           # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           
+           # See the License for the specific language governing permissions and
+           
+           # limitations under the License.
+           
+           #
+           
+           
+           
+           package templates.gcp.GCPBigQueryDatasetLocationConstraintV1
+           
+           
+           
+           import data.validator.gcp.lib as lib
+           
+           
+           
+           ############################################
+           
+           # Find BigQuery Dataset Location Violations
+           
+           ############################################
+           
+           deny[{
+           
+           	"msg": message,
+           
+           	"details": metadata,
+           
+           }] {
+           
+           	constraint := input.constraint
+           
+           	lib.get_constraint_params(constraint, params)
+           
+           
+           
+           	# Verify that resource is BigQuery dataset
+           
+           	asset := input.asset
+           
+           	asset.asset_type == "bigquery.googleapis.com/Dataset"
+           
+           
+           
+           	# Check if resource is in exempt list
+           
+           	exempt_list := params.exemptions
+           
+           	matches := {asset.name} & cast_set(exempt_list)
+           
+           	count(matches) == 0
+           
+           
+           
+           	# Check that location is in allowlist/denylist
+           
+           	target_locations := params.locations
+           
+           	asset_location := asset.resource.data.location
+           
+           	location_matches := {asset_location} & cast_set(target_locations)
+           
+           	target_location_match_count(params.mode, desired_count)
+           
+           	count(location_matches) == desired_count
+           
+           
+           
+           	message := sprintf("%v is in a disallowed location.", [asset.name])
+           
+           	metadata := {"location": asset_location}
+           
+           }
+           
+           
+           
+           #################
+           
+           # Rule Utilities
+           
+           #################
+           
+           
+           
+           # Determine the overlap between locations under test and constraint
+           
+           # By default (allowlist), we violate if there isn't overlap
+           
+           target_location_match_count(mode) = 0 {
+           
+           	mode != "denylist"
+           
+           }
+           
+           
+           
+           target_location_match_count(mode) = 1 {
+           
+           	mode == "denylist"
+           
+           }
+           
+           #ENDINLINE


### PR DESCRIPTION
Resources with an OpenAPI spec were not converting properly since the
schemes were not registered.  This fixes the panic.