### PR TITLE
Fix up issue with legacy matcher formatting.

### DIFF
--- a/pkg/gcv/configs/config_test.go
+++ b/pkg/gcv/configs/config_test.go
@@ -471,3 +471,43 @@ func cleanup(t *testing.T, dir string) {
 		t.Log(err)
 	}
 }
+
+func TestFixLegacyMatcher(t *testing.T) {
+	var testCases = []struct {
+		input string
+		want  string
+	}{
+		{
+			"organization/*",
+			"organizations/**",
+		},
+		{
+			"folder/*",
+			"folders/**",
+		},
+		{
+			"project/*",
+			"projects/**",
+		},
+		{
+			"organization/*/folder/*",
+			"organizations/**/folders/**",
+		},
+		{
+			"organization/*/project/*",
+			"organizations/**/projects/**",
+		},
+		{
+			"organization/*/folder/*/project/*",
+			"organizations/**/folders/**/projects/**",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := fixLegacyMatcher(tc.input)
+			if got != tc.want {
+				t.Errorf("input %s wanted %s, got %s", tc.input, tc.want, got)
+			}
+		})
+	}
+}

--- a/test/cf/constraints/cf_gcp_storage_logging_constraint.yaml
+++ b/test/cf/constraints/cf_gcp_storage_logging_constraint.yaml
@@ -22,6 +22,5 @@ metadata:
 spec:
   severity: high
   match:
-    gcp:
-      target: ["organization/*"]
+    target: ["organizations/**"]
   parameters: {}

--- a/test/cf/constraints/gcp_storage_logging_constraint.yaml
+++ b/test/cf/constraints/gcp_storage_logging_constraint.yaml
@@ -22,6 +22,5 @@ metadata:
 spec:
   severity: high
   match:
-    gcp:
-      target: ["organization/*"]
+    target: ["organization/*"]
   parameters: {}


### PR DESCRIPTION
Prior matchers would format "organization/*" rather than a standard glob
formatting like "organziations/**".  This fixes legacy support for
"organziation/*" for old-style constraints.