### PR TITLE
Have config validator emit all constraint / constraint template errors.

### DIFF
--- a/pkg/gcv/configs/config.go
+++ b/pkg/gcv/configs/config.go
@@ -385,6 +385,7 @@ func (c *Configuration) loadUnstructured(u *unstructured.Unstructured) error {
 		if err := convertLegacyConstraint(u); err != nil {
 			return errors.Wrapf(err, "failed to convert constraint")
 		}
+
 		c.Constraints = append(c.Constraints, u)
 	default:
 		return errors.Errorf("unexpected data type %s", u.GroupVersionKind())

--- a/pkg/gcv/validator.go
+++ b/pkg/gcv/validator.go
@@ -108,16 +108,23 @@ func NewValidatorFromConfig(stopChannel <-chan struct{}, config *configs.Configu
 	}
 
 	ctx := context.Background()
+	var errs multierror.Errors
 	for _, template := range config.Templates {
 		if _, err := client.AddTemplate(ctx, template); err != nil {
-			return nil, errors.Wrapf(err, "failed to add template %v", template)
+			errs.Add(errors.Wrapf(err, "failed to add template %v", template))
 		}
+	}
+	if !errs.Empty() {
+		return nil, errs.ToError()
 	}
 
 	for _, constraint := range config.Constraints {
 		if _, err := client.AddConstraint(ctx, constraint); err != nil {
-			return nil, errors.Wrapf(err, "failed to add constraint %s", constraint)
+			errs.Add(errors.Wrapf(err, "failed to add constraint %s", constraint))
 		}
+	}
+	if !errs.Empty() {
+		return nil, errs.ToError()
 	}
 
 	ret := &Validator{


### PR DESCRIPTION
Instead of failing on first error, this will cause FCV to emit all template and constraint errors.