### PR TITLE
Refactor threading into ParallelValidator

### DIFF
--- a/cmd/policy-tool/lint/lint.go
+++ b/cmd/policy-tool/lint/lint.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func lintCmd(cmd *cobra.Command, args []string) error {
-	_, err := gcv.NewValidator(make(chan struct{}), flags.policies, flags.libs)
+	_, err := gcv.NewValidator(flags.policies, flags.libs)
 	if err != nil {
 		fmt.Printf("linter errors:\n%s\n", err)
 		os.Exit(1)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -42,7 +42,7 @@ var (
 )
 
 type gcvServer struct {
-	validator *gcv.Validator
+	validator *gcv.ParallelValidator
 }
 
 func (s *gcvServer) AddData(ctx context.Context, request *validator.AddDataRequest) (*validator.AddDataResponse, error) {
@@ -62,10 +62,11 @@ func (s *gcvServer) Review(ctx context.Context, request *validator.ReviewRequest
 }
 
 func newServer(stopChannel chan struct{}, policyPaths []string, policyLibraryPath string) (*gcvServer, error) {
-	v, err := gcv.NewValidator(stopChannel, policyPaths, policyLibraryPath)
+	cv, err := gcv.NewValidator(policyPaths, policyLibraryPath)
 	if err != nil {
 		return nil, err
 	}
+	v := gcv.NewParallelValidator(stopChannel, cv)
 	return &gcvServer{
 		validator: v,
 	}, nil

--- a/pkg/gcv/parallelvalidator.go
+++ b/pkg/gcv/parallelvalidator.go
@@ -1,0 +1,113 @@
+package gcv
+
+import (
+	"context"
+	"flag"
+	"runtime"
+
+	"github.com/forseti-security/config-validator/pkg/api/validator"
+	"github.com/forseti-security/config-validator/pkg/multierror"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+)
+
+var flags struct {
+	workerCount int
+}
+
+func init() {
+	flag.IntVar(
+		&flags.workerCount,
+		"workerCount",
+		runtime.NumCPU(),
+		"Number of workers that Validator will spawn to handle validate calls, this defaults to core count on the host")
+}
+
+// ParallelValidator handles making parallel calls to Validator during a Review call.
+type ParallelValidator struct {
+	cv   ConfigValidator
+	work chan func()
+}
+
+type assetResult struct {
+	violations []*validator.Violation
+	err        error
+}
+
+// NewParallelValidator creates a new instance with the given stop channel and validator
+func NewParallelValidator(stopChannel <-chan struct{}, cv ConfigValidator) *ParallelValidator {
+	pv := &ParallelValidator{
+		// channel size of number of workers seems sufficient to prevent blocking,
+		// this is really just an assumption with no actual perf benchmarking.
+		work: make(chan func(), flags.workerCount),
+		cv:   cv,
+	}
+
+	go func() {
+		<-stopChannel
+		glog.Infof("validator shutdown requested via stopChannel close")
+		close(pv.work)
+	}()
+
+	workerCount := flags.workerCount
+	glog.Infof("validator starting %d workers", workerCount)
+	for i := 0; i < workerCount; i++ {
+		go pv.reviewWorker(i)
+	}
+
+	return pv
+}
+
+// reviewWorker is the function that each worker goroutine will use
+func (v *ParallelValidator) reviewWorker(idx int) {
+	glog.V(1).Infof("worker %d starting", idx)
+	for f := range v.work {
+		f()
+	}
+	glog.V(1).Infof("worker %d terminated", idx)
+}
+
+// handleReview is the wrapper function for individual asset reviews.
+func (v *ParallelValidator) handleReview(ctx context.Context, idx int, asset *validator.Asset, resultChan chan<- *assetResult) func() {
+	return func() {
+		resultChan <- func() *assetResult {
+			violations, err := v.cv.ReviewAsset(ctx, asset)
+			if err != nil {
+				return &assetResult{err: errors.Wrapf(err, "index %d", idx)}
+			}
+			return &assetResult{violations: violations}
+		}()
+	}
+}
+
+// Review evaluates each asset in the review request in parallel and returns any
+// violations found.
+func (v *ParallelValidator) Review(ctx context.Context, request *validator.ReviewRequest) (*validator.ReviewResponse, error) {
+	assetCount := len(request.Assets)
+	// channel size of number of workers seems sufficient to prevent blocking,
+	// this is really just an assumption with no actual perf benchmarking.
+	resultChan := make(chan *assetResult, flags.workerCount)
+	defer close(resultChan)
+
+	go func() {
+		for idx, asset := range request.Assets {
+			v.work <- v.handleReview(ctx, idx, asset, resultChan)
+		}
+	}()
+
+	response := &validator.ReviewResponse{}
+	var errs multierror.Errors
+	for i := 0; i < assetCount; i++ {
+		result := <-resultChan
+		if result.err != nil {
+			errs.Add(result.err)
+			continue
+		}
+		response.Violations = append(response.Violations, result.violations...)
+	}
+
+	if !errs.Empty() {
+		return response, errs.ToError()
+	}
+	return response, nil
+}

--- a/pkg/gcv/parallelvalidator_test.go
+++ b/pkg/gcv/parallelvalidator_test.go
@@ -1,0 +1,192 @@
+package gcv
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/forseti-security/config-validator/pkg/api/validator"
+)
+
+type reviewTestcase struct {
+	name        string
+	workerCount int
+	calls       []reviewCall
+}
+
+type reviewCall struct {
+	assets             []*validator.Asset // assets to use if not using the default asset set
+	scaleFactor        int                // number of copies of asset list to put in one call to Review.
+	wantViolationCount int                // the total violation count
+	wantError          bool
+}
+
+type FakeConfigValidator struct {
+	violationMap map[string][]*validator.Violation
+}
+
+func NewFakeConfigValidator(violationMap map[string][]*validator.Violation) *FakeConfigValidator {
+	for name, violations := range violationMap {
+		for _, v := range violations {
+			v.Resource = name
+		}
+	}
+	return &FakeConfigValidator{violationMap: violationMap}
+}
+
+func (v *FakeConfigValidator) ReviewAsset(ctx context.Context, asset *validator.Asset) ([]*validator.Violation, error) {
+	violations, found := v.violationMap[asset.Name]
+	if !found {
+		return nil, errors.Errorf("name %s not found", asset.Name)
+	}
+	return violations, nil
+}
+
+func TestReview(t *testing.T) {
+	// we will run 3x this amount of assets through audit, then reset at end
+	// of test.
+	var testCases = []reviewTestcase{
+		{
+			name:        "no assets",
+			workerCount: 1,
+			calls: []reviewCall{
+				{
+					assets: []*validator.Asset{},
+				},
+			},
+		},
+		{
+			name:        "error",
+			workerCount: 1,
+			calls: []reviewCall{
+				{
+					assets:    []*validator.Asset{{Name: "invalid name"}},
+					wantError: true,
+				},
+			},
+		},
+		{
+			name:        "single call",
+			workerCount: 1,
+			calls: []reviewCall{
+				{
+					assets:             []*validator.Asset{storageAssetNoLogging()},
+					wantViolationCount: 2,
+				},
+			},
+		},
+		{
+			name:        "single call three assets",
+			workerCount: 1,
+			calls: []reviewCall{
+				{
+					assets:             defaultReviewTestAssets,
+					wantViolationCount: 3,
+				},
+			},
+		},
+	}
+
+	var testCase *reviewTestcase
+	testCase = &reviewTestcase{
+		name:        "128 goroutines x32 calls x16 scale",
+		workerCount: 128,
+	}
+	for i := 0; i < 32; i++ {
+		testCase.calls = append(
+			testCase.calls,
+			reviewCall{
+				assets:             defaultReviewTestAssets,
+				scaleFactor:        16,
+				wantViolationCount: 3,
+			},
+		)
+	}
+	testCases = append(testCases, *testCase)
+	testCase = &reviewTestcase{
+		name:        "single call large scale deadlock test",
+		workerCount: 4,
+		calls: []reviewCall{
+			{
+				assets:             defaultReviewTestAssets,
+				scaleFactor:        4 * 16,
+				wantViolationCount: 3,
+			},
+		},
+	}
+	testCases = append(testCases, *testCase)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldWorkerCount := flags.workerCount
+			defer func() {
+				flags.workerCount = oldWorkerCount
+			}()
+			flags.workerCount = tc.workerCount
+
+			stopChannel := make(chan struct{})
+			defer close(stopChannel)
+			cv := NewFakeConfigValidator(
+				map[string][]*validator.Violation{
+					"//storage.googleapis.com/my-storage-bucket-with-logging":        nil,
+					"//storage.googleapis.com/my-storage-bucket-with-secure-logging": nil,
+					"//container.googleapis.com/projects/malaise-forever/zones/us-central1-a/clusters/test-1/k8s/namespaces/whatever": {
+						{
+							Constraint: "namespace-cost-center-label",
+							Message:    "you must provide labels: {\"cost-center\"}",
+						},
+					},
+					"//storage.googleapis.com/my-storage-bucket": {
+						{
+							Constraint: "require-storage-logging",
+							Message:    "//storage.googleapis.com/my-storage-bucket does not have the required logging destination.",
+						},
+						{
+							Constraint: "require-storage-logging-xx",
+							Message:    "//storage.googleapis.com/my-storage-bucket does not have the required logging destination.",
+						},
+					},
+				},
+			)
+			v := NewParallelValidator(stopChannel, cv)
+
+			var groupDone sync.WaitGroup
+			for callIdx, call := range tc.calls {
+				groupDone.Add(1)
+				go func(cIdx int, call reviewCall) {
+					defer groupDone.Done()
+					if call.scaleFactor == 0 {
+						call.scaleFactor = 1
+					}
+
+					var assets []*validator.Asset
+					for i := 0; i < call.scaleFactor; i++ {
+						assets = append(assets, call.assets...)
+					}
+
+					result, err := v.Review(context.Background(), &validator.ReviewRequest{
+						Assets: assets,
+					})
+					if call.wantError {
+						if err == nil {
+							t.Fatal("Expected error, got none")
+						}
+						return
+					} else {
+						if err != nil {
+							t.Fatalf("review error in call %d: %s", cIdx, err)
+						}
+					}
+
+					wantViolationCount := call.wantViolationCount * call.scaleFactor
+					if len(result.Violations) != wantViolationCount {
+						t.Fatalf("wanted %d violations, got %d", wantViolationCount, len(result.Violations))
+					}
+				}(callIdx, call)
+			}
+			groupDone.Wait()
+		})
+	}
+}

--- a/test/cf/constraints/all_namespace_must_have_cost_center.yaml
+++ b/test/cf/constraints/all_namespace_must_have_cost_center.yaml
@@ -1,7 +1,7 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
-  name: pod-must-have-gk
+  name: namespace-cost-center-label
 spec:
   match:
     kinds:


### PR DESCRIPTION
This change is intended to simplify Validator to enable emitting results
in a format other than Violation.