### PR TITLE
Adjust dockerfile build step to cache mod download.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,14 @@
 FROM golang:1.12 as build
 
 WORKDIR /go/src/app
-COPY . .
 
+# Cache dependency download step
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy all sources and build
+COPY . .
 RUN make linux
 
 # Now copy it into our static image.


### PR DESCRIPTION
This brings down local cloudbuild execution time from ~2m45s to ~50s on
consecuitive builds where go.mod/go.sum do not change.