### PR TITLE
Have policy tool push to tag wtih commit hash.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ $(POLICY_TOOLS):
 	GO111MODULE=on GOOS=$(subst policy-tool-,,$@) GOARCH=amd64 CGO_ENABLED=0 \
 		go build -o "${BUILD_DIR}/$@-amd64" cmd/policy-tool/policy-tool.go
 
+DIRTY := $(shell git diff --no-ext-diff --quiet --exit-code || echo -n -dirty)
+TAG := $(shell git log -n1 --pretty=format:%h)
+IMAGE := gcr.io/config-validator/policy-tool:commit-$(TAG)$(DIRTY)
 policy-tool-docker:
-	docker build -t gcr.io/config-validator/policy-tool -f ./build/policy-tool/Dockerfile .
-
+	docker build -t $(IMAGE) -f ./build/policy-tool/Dockerfile .
+	docker push $(IMAGE)

--- a/cmd/policy-tool/lint/lint.go
+++ b/cmd/policy-tool/lint/lint.go
@@ -47,7 +47,7 @@ func init() {
 func lintCmd(cmd *cobra.Command, args []string) error {
 	_, err := gcv.NewValidator(flags.policies, flags.libs)
 	if err != nil {
-		fmt.Printf("linter errors:\n%s\n", err)
+		fmt.Printf("linter errors:\n%v\n", err)
 		os.Exit(1)
 	}
 	fmt.Printf("No lint errors found.\n")

--- a/pkg/multierror/multierror.go
+++ b/pkg/multierror/multierror.go
@@ -40,10 +40,11 @@ func (errs errorImpl) Format(s fmt.State, verb rune) {
 		_, _ = fmt.Fprintf(s, "errors (%d):\n", len(errs))
 		for _, err := range errs {
 			if formatter, ok := err.(fmt.Formatter); ok {
+				_, _ = io.WriteString(s, "  ")
 				formatter.Format(s, verb)
 				_, _ = io.WriteString(s, "\n")
 			} else {
-				_, _ = fmt.Fprintf(s, "%v\n", err)
+				_, _ = fmt.Fprintf(s, "  %v\n", err)
 			}
 		}
 


### PR DESCRIPTION
We don't yet have tags for versions, so use the commit hash for the time being
to version the image that policy-library uses in CI