### PR TITLE
increase cloud build timeout from 20min to 30min 

### DIFF
--- a/build/cloudbuild/build-cloudbuild.yaml
+++ b/build/cloudbuild/build-cloudbuild.yaml
@@ -46,4 +46,4 @@ images:
 - 'gcr.io/$PROJECT_ID/config-validator:latest'
 - 'gcr.io/$PROJECT_ID/config-validator:$SHORT_SHA'
 
-timeout: 1200s
+timeout: 1800s


### PR DESCRIPTION
Increase cloud build timeout from 20min to 30min because `docker build -t gcv-proto-builder -f ./build/proto/Dockerfile .` needs more than 20mins