### PR TITLE
Fix error message in UnwrapCAIResource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 bin/
 
+# build artifacts
+/build-grpc/
+
 # intellij stuff
 /.idea/
 /config-validator.iml

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -149,10 +149,10 @@ func UnwrapCAIResource(asset map[string]interface{}) (*unstructured.Unstructured
 
 	ancestors, found, err := unstructured.NestedStringSlice(asset, "ancestors")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to access resource.data field")
+		return nil, errors.Wrapf(err, "failed to access ancestors field")
 	}
 	if !found {
-		return nil, errors.Errorf("resource.data field not found")
+		return nil, errors.Errorf("ancestors field not found")
 	}
 
 	annotations := u.GetAnnotations()


### PR DESCRIPTION
Update the error message to mention ancestors instead of resource.data. Update .gitignore to ignore build artifacts from `make pyproto`.

Resolves #147 