### PR TITLE
Remove Forseti name from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Forseti Config Validator
+# Config Validator
 
 This is a Golang library which provides functionality to evaluate
 GCP resources against Rego-based policies. It can be used to add


### PR DESCRIPTION
(Since we have multiple clients now, this name isn't really accurate.)